### PR TITLE
Add Alpine support through musl-fts flag

### DIFF
--- a/README
+++ b/README
@@ -348,9 +348,17 @@ $ autoreconf -i
 (autoreconf comes from the GNU autotools), then run :
 
 $ ./configure
+
+If you are installing on a node alpine image, make sure the `fts-dev` package is
+installed and pass the `--enable-muslfts` option.
+
+$ ./configure --enable-muslfts
+
+Then run :
+
 $ make
 
-to configure and build fpart.
+to build fpart.
 
 Finally, install fpart (as root) :
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,19 @@ AC_ARG_ENABLE([embfts],
   *) AC_MSG_ERROR([bad value ${enableval} for --enable-embfts]) ;;
 esac],[embfts=${dflt_embfts}])
 
+# Default value for musl-fts support
+dflt_muslfts=false
+# TODO: Can we detect alpine (and maybe if musl-fts is available) to set default to true?
+
+# System musl-fts for Alpine option
+AC_ARG_ENABLE([muslfts],
+[  --enable-muslfts         enable musl-fts],
+[case "${enableval}" in
+  yes) muslfts=true ;;
+  no)  muslfts=false ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-muslfts]) ;;
+esac],[muslfts=${dflt_muslfts}])
+
 # Static build option
 AC_ARG_ENABLE([static],
 [  --enable-static         build static binary],
@@ -84,6 +97,7 @@ AC_SYS_LARGEFILE
 # Automake output
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 AM_CONDITIONAL([EMBEDDED_FTS], [test x$embfts = xtrue])
+AM_CONDITIONAL([MUSL_FTS], [test x$muslfts = xtrue])
 AM_CONDITIONAL([SOLARIS], [test x$host_os_solaris = xtrue])
 AM_CONDITIONAL([LINUX], [test x$host_os_linux = xtrue])
 AM_CONDITIONAL([STATIC], [test x$static = xtrue])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,6 @@ bin_PROGRAMS = fpart
 fpart_SOURCES = types.h utils.c utils.h options.c options.h partition.c partition.h file_entry.c file_entry.h dispatch.c dispatch.h fpart.c fpart.h
 fpart_CFLAGS =
 fpart_LDFLAGS =
-LIBS += -lfts
 
 if DEBUG
 fpart_CFLAGS += -g -DDEBUG

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,10 @@ fpart_SOURCES += fts.c fts.h
 fpart_CFLAGS += -DEMBED_FTS
 endif
 
+if MUSL_FTS
+LIBS += -lfts
+endif
+
 if SOLARIS
 fpart_CFLAGS += -D_POSIX_C_SOURCE=200112L -D__EXTENSIONS__ -xc99
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,9 @@ AUTOMAKE_OPTIONS = nostdinc
 
 bin_PROGRAMS = fpart
 fpart_SOURCES = types.h utils.c utils.h options.c options.h partition.c partition.h file_entry.c file_entry.h dispatch.c dispatch.h fpart.c fpart.h
-fpart_CFLAGS = -lfts
+fpart_CFLAGS =
 fpart_LDFLAGS =
+LIBS += -lfts
 
 if DEBUG
 fpart_CFLAGS += -g -DDEBUG

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ AUTOMAKE_OPTIONS = nostdinc
 
 bin_PROGRAMS = fpart
 fpart_SOURCES = types.h utils.c utils.h options.c options.h partition.c partition.h file_entry.c file_entry.h dispatch.c dispatch.h fpart.c fpart.h
-fpart_CFLAGS =
+fpart_CFLAGS = -lfts
 fpart_LDFLAGS =
 
 if DEBUG


### PR DESCRIPTION
This adds a `--enable-muslfts` flag for `configure` that will add the `-lfts` flag to compilation so that the system `musl-fts` binaries are properly linked when compiling on a node alpine docker image.